### PR TITLE
Implement pump labeling utility

### DIFF
--- a/sim/backtest_alpha.py
+++ b/sim/backtest_alpha.py
@@ -1,6 +1,12 @@
 """Standalone pump-classifier training."""
 from pathlib import Path
+import pandas as pd
 from src.alpha.trainer import offline_train
+from .label_pumps import label_pumps
+
+CSV = Path("data/pump_events.csv")
 
 if __name__ == "__main__":
-    offline_train(Path("data/pump_events.csv"))
+    if not CSV.exists() or len(pd.read_csv(CSV)) < 30:
+        label_pumps(CSV)
+    offline_train(CSV)

--- a/sim/label_pumps.py
+++ b/sim/label_pumps.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import yaml
+import pandas as pd
+
+from src.data_ingest.price_loader import PriceLoader
+from src.data_ingest.volume_anomaly import volume_zscore
+
+
+def label_pumps(output: Path = Path("data/pump_events.csv")) -> Path:
+    """Label pump events across configured universe and save to CSV."""
+    with open("config/base.yaml") as f:
+        cfg = yaml.safe_load(f)
+    symbols = cfg.get("universe", {}).get("symbols", [])
+
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=90)
+    loader = PriceLoader()
+    frames = []
+    for sym in symbols:
+        df = loader.load(sym, start, end)
+        if df.empty:
+            continue
+        df["ret"] = df["c"].pct_change()
+        df["vol_z"] = volume_zscore(df["v"])
+        df["is_pump"] = ((df["ret"] > 0.9) & (df["vol_z"] > 4)).astype(int)
+        frames.append(df[["ret", "vol_z", "is_pump"]])
+
+    if not frames:
+        return output
+
+    all_rows = pd.concat(frames).dropna()
+    if output.exists():
+        prev = pd.read_csv(output)
+        all_rows = pd.concat([prev, all_rows])
+    all_rows = all_rows.drop_duplicates()
+    all_rows.to_csv(output, index=False)
+    return output
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    label_pumps()

--- a/tests/test_autolabel.py
+++ b/tests/test_autolabel.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+import pandas as pd
+from sim.label_pumps import label_pumps
+from src.data_ingest.price_loader import PriceLoader
+
+
+def test_label_pumps(monkeypatch, tmp_path):
+    def fake_load(self, symbol, start, end, timeframe="1d", limit=1000):
+        dates = pd.date_range(end - timedelta(days=89), end, freq="D")
+        df = pd.DataFrame({
+            "o": 1.0,
+            "h": 1.0,
+            "l": 1.0,
+            "c": 1.0,
+            "v": 1.0,
+        }, index=dates)
+        spike_idx = dates[-2]
+        df.loc[spike_idx, ["o", "h", "l", "c"]] = 2.0
+        df.loc[spike_idx, "v"] = 100.0
+        return df
+
+    monkeypatch.setattr(PriceLoader, "load", fake_load)
+    out = tmp_path / "pump_events.csv"
+    label_pumps(out)
+    df = pd.read_csv(out)
+    assert (df["is_pump"] == 1).any()


### PR DESCRIPTION
## Summary
- label pumps across configured universe
- auto generate pump_events.csv in backtest_alpha
- test autolabeling using monkeypatched PriceLoader

## Testing
- `poetry run ruff check .` *(fails: multiple lint errors)*
- `poetry run mypy src` *(fails: missing type stubs)*
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507c3f417c832c9fb0fddcc47ceac3