### PR TITLE
Add Convexity Sleeve configuration

### DIFF
--- a/config/sleeve.yaml
+++ b/config/sleeve.yaml
@@ -1,0 +1,22 @@
+# Convexity Sleeve default configuration
+# Values follow units indicated below
+
+# capital allocation
+budget_pct_nav: 0.5        # fraction of NAV allocated daily (0 < ≤ 1.0)
+
+# execution venue
+exchange: "deribit"       # option venue string
+
+# trade parameters
+moneyness: 5.0            # strike/spot ratio ≥ 1.0
+days_to_expiry: [1, 2, 3] # list of integer expiries (1–30)
+
+# volatility filter
+iv_percentile_max: 20     # top IV percentile filter (0 < ≤ 100)
+
+# order management
+slippage_bps: 15          # max bps slippage per fill (≥ 0)
+take_profit_pct: 900      # profit target as percent of entry (≥ 0)
+
+# caching
+cache_ttl_min: 10         # cache TTL in minutes (≥ 1)


### PR DESCRIPTION
## Summary
- add sleeve parameters for the Convexity Sleeve extension

## Testing
- `python - <<'PY'
import yaml
with open('config/sleeve.yaml') as f:
    data = yaml.safe_load(f)
print(data)
PY`
- `python - <<'PY'
import yaml, sys
with open('config/sleeve.yaml') as f:
    data = yaml.safe_load(f)
errs=[]
if not (0 < data['budget_pct_nav'] <= 1):
    errs.append('budget_pct_nav out of range')
if data['moneyness'] < 1.0:
    errs.append('moneyness out of range')
if not all(1 <= d <= 30 for d in data['days_to_expiry']):
    errs.append('days_to_expiry out of range')
if not (0 < data['iv_percentile_max'] <= 100):
    errs.append('iv_percentile_max out of range')
if data['slippage_bps'] < 0:
    errs.append('slippage_bps out of range')
if data['take_profit_pct'] < 0:
    errs.append('take_profit_pct out of range')
if data['cache_ttl_min'] < 1:
    errs.append('cache_ttl_min out of range')
if errs:
    print('ERROR', errs)
else:
    print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68508cfa775c832c9244657e0cbbbeba