### PR TITLE
[ci] update coverage threshold

### DIFF
--- a/infra/ci.yml
+++ b/infra/ci.yml
@@ -11,4 +11,4 @@ jobs:
     - run: poetry install
     - run: poetry run ruff check .
     - run: poetry run mypy src
-    - run: poetry run pytest --cov=src --cov-fail-under=85
+    - run: poetry run pytest --cov=src --cov-fail-under=92


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [ ] Feature
- [x] Refactor / chore

### Description
- raise coverage requirement in CI to 92%

### Validation
```bash
poetry run ruff check .
poetry run mypy src --install-types --non-interactive
poetry run pytest -q
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk

*Drawdown risk unchanged (max-DD guard still 18 %).*

------
https://chatgpt.com/codex/tasks/task_e_6850aee28ae0832c9c96276a9b1fd021