### PR TITLE
[tests] boost coverage past 92%

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,17 @@
+from src.state import persistence
+
+
+def test_save_and_load_state(tmp_path, monkeypatch):
+    path = tmp_path / "state.joblib"
+    monkeypatch.setattr(persistence, "_STATE", path)
+    data = {"a": 1}
+    persistence.save_state(data)
+    assert path.exists()
+    loaded = persistence.load_state()
+    assert loaded == data
+
+
+def test_load_state_missing(tmp_path, monkeypatch):
+    path = tmp_path / "missing.joblib"
+    monkeypatch.setattr(persistence, "_STATE", path)
+    assert persistence.load_state() is None

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta, timezone
+
+from src.options.position_manager import PositionManager
+
+
+def test_add_and_premium():
+    pm = PositionManager()
+    expiry = datetime.now(timezone.utc) + timedelta(days=1)
+    pm.add_position("BTC", 2, 100.0, expiry, tp_pct=10)
+    pm.add_position("ETH", 1, 50.0, expiry, tp_pct=20)
+    assert len(pm.positions) == 2
+    assert pm.open_premium() == 250.0
+    assert pm.budget_spent == 250.0
+
+
+def test_check_exits(monkeypatch):
+    pm = PositionManager()
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+    pm.add_position("BTC", 1, 100.0, past, tp_pct=10)
+    pm.add_position("ETH", 1, 100.0, future, tp_pct=10)
+
+    def price_fn(symbol: str) -> float:
+        return 200.0 if symbol == "ETH" else 0.0
+
+    exited = pm.check_exits(price_fn)
+    assert {p.symbol for p in exited} == {"BTC", "ETH"}
+    assert pm.positions == []
+    assert pm.budget_spent == 0.0


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [x] Feature
- [ ] Refactor / chore

### Description
- add unit tests for state persistence helpers
- add unit tests for option position manager

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk
*Drawdown risk unchanged (max-DD guard still 18 %).*

------
https://chatgpt.com/codex/tasks/task_e_6850b35108bc832cbab44fdcf25f535b