### PR TITLE
[execution] change default exchange to kraken

### DIFF
--- a/src/data_ingest/price_loader.py
+++ b/src/data_ingest/price_loader.py
@@ -11,7 +11,7 @@ import time
 class PriceLoader:
     """Fetch OHLCV data from exchanges via ccxt."""
 
-    def __init__(self, exchange: str = "binance") -> None:
+    def __init__(self, exchange: str = "kraken") -> None:
         """Initialize loader with the given exchange."""
 
         self.ex = getattr(ccxt, exchange)()

--- a/src/execution/ccxt_router.py
+++ b/src/execution/ccxt_router.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class CcxtRouter:
     """Thin wrapper over ccxt for order placement."""
 
-    def __init__(self, exchange: str = "binance") -> None:
+    def __init__(self, exchange: str = "kraken") -> None:
         """Connect to the specified exchange using API keys from the environment."""
 
         klass = getattr(ccxt, exchange)

--- a/src/universe/filter.py
+++ b/src/universe/filter.py
@@ -20,7 +20,7 @@ class UniverseFilter:
         *,
         min_adv_usd: float,
         min_mcap_usd: float,
-        exchange: str = "binance",
+        exchange: str = "kraken",
         supply_fetcher: Callable[[str], float] = coingecko_supply,
     ) -> None:
         self.min_adv, self.min_mcap = min_adv_usd, min_mcap_usd


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [ ] Feature
- [x] Refactor / chore

### Description
- default exchange in `CcxtRouter`, `PriceLoader`, and `UniverseFilter` set to `kraken`
- no behavior changes besides new default

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk

*Drawdown risk unchanged (max-DD guard still 18 %).*

Fixes #

------
https://chatgpt.com/codex/tasks/task_e_686c361d2ebc832c82a28d576c5265a6