### PR TITLE
[infra] add secret provider for API keys

### DIFF
--- a/src/execution/ccxt_router.py
+++ b/src/execution/ccxt_router.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 import logging
-import os
 
 import ccxt
-from dotenv import load_dotenv
-
-load_dotenv()
+from src.infra.secret_provider import get_secret
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +15,7 @@ class CcxtRouter:
 
         klass = getattr(ccxt, exchange)
         self.client = klass(
-            {"apiKey": os.getenv("EXCHANGE_API_KEY"), "secret": os.getenv("EXCHANGE_API_SECRET")}
+            {"apiKey": get_secret("EXCHANGE_API_KEY"), "secret": get_secret("EXCHANGE_API_SECRET")}
         )
 
     def place_order(self, symbol: str, side: str, size: float, price: float | None = None):

--- a/src/infra/secret_provider.py
+++ b/src/infra/secret_provider.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_secret(key: str) -> str:
+    """Return a secret from environment variables."""
+    value = os.getenv(key)
+    if not value:
+        raise KeyError(f"Missing secret {key}")
+    return value

--- a/src/options/deribit_router.py
+++ b/src/options/deribit_router.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import os
 from typing import Any, Dict, Mapping, cast
 
 import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
 from urllib3.util import Retry
-from dotenv import load_dotenv
-
-load_dotenv()
+from src.infra.secret_provider import get_secret
 
 
 class DeribitRouter:
@@ -20,10 +17,8 @@ class DeribitRouter:
     def __init__(self) -> None:
         """Create a session and authenticate using environment credentials."""
 
-        self.client_id: str | None = os.getenv("DERIBIT_CLIENT_ID")
-        self.client_secret: str | None = os.getenv("DERIBIT_CLIENT_SECRET")
-        if not self.client_id or not self.client_secret:
-            raise ValueError("Missing Deribit credentials")
+        self.client_id: str = get_secret("DERIBIT_CLIENT_ID")
+        self.client_secret: str = get_secret("DERIBIT_CLIENT_SECRET")
 
         self.session = requests.Session()
         adapter = HTTPAdapter(

--- a/tests/test_ccxt_router.py
+++ b/tests/test_ccxt_router.py
@@ -1,7 +1,12 @@
 from src.execution.ccxt_router import CcxtRouter
 
 
+def _fake_secret(key: str) -> str:
+    return "x"
+
+
 def test_ccxt_router(monkeypatch):
+    monkeypatch.setattr("src.execution.ccxt_router.get_secret", _fake_secret)
     router = CcxtRouter()
     called = {}
     monkeypatch.setattr(router.client, "create_limit_order", lambda s, side, size, price: called.setdefault("limit", price))

--- a/tests/test_secret_provider.py
+++ b/tests/test_secret_provider.py
@@ -1,0 +1,13 @@
+from src.infra.secret_provider import get_secret
+import pytest
+
+
+def test_get_secret_valid(monkeypatch):
+    monkeypatch.setenv("SOME_KEY", "val")
+    assert get_secret("SOME_KEY") == "val"
+
+
+def test_get_secret_missing(monkeypatch):
+    monkeypatch.delenv("NO_KEY", raising=False)
+    with pytest.raises(KeyError):
+        get_secret("NO_KEY")

--- a/tests/test_stop_loss.py
+++ b/tests/test_stop_loss.py
@@ -2,6 +2,10 @@ import pandas as pd
 from src.execution.trade_manager import TradeManager
 
 
+def _fake_secret(key: str) -> str:
+    return "x"
+
+
 def test_stop_loss(monkeypatch):
     risk = {
         "max_drawdown_pct": 18,
@@ -10,6 +14,7 @@ def test_stop_loss(monkeypatch):
         "corr_spike_thresh": 1.0,
         "stop_loss_pct": 10,
     }
+    monkeypatch.setattr("src.execution.ccxt_router.get_secret", _fake_secret)
     tm = TradeManager(1000, risk)
     monkeypatch.setattr("src.execution.trade_manager.load_state", lambda: None)
     monkeypatch.setattr("src.execution.trade_manager.save_state", lambda s: None)

--- a/tests/test_trade_pass_path.py
+++ b/tests/test_trade_pass_path.py
@@ -2,6 +2,10 @@ import pandas as pd
 from src.execution.trade_manager import TradeManager, Trade
 
 
+def _fake_secret(key: str) -> str:
+    return "x"
+
+
 def test_execute_trade_pass_path(monkeypatch, price_series):
     """TradeManager returns Trade on risk pass and updates drawdown."""
     # disable persistence
@@ -9,6 +13,7 @@ def test_execute_trade_pass_path(monkeypatch, price_series):
     monkeypatch.setattr("src.execution.trade_manager.save_state", lambda state: None)
 
     risk_cfg = {"max_drawdown_pct": 18, "adv_cap_pct": 2, "var_confidence": 0.95, "corr_spike_thresh": 1.0}
+    monkeypatch.setattr("src.execution.ccxt_router.get_secret", _fake_secret)
     tm = TradeManager(10000, risk_cfg)
 
     monkeypatch.setattr(tm.router, "place_order", lambda symbol, side, size, price=None: None)


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [x] Feature
- [x] Refactor / chore

### Description
- created `src/infra/secret_provider.py` with `get_secret`
- updated `CcxtRouter` and `DeribitRouter` to use provider
- added tests for provider and patched existing tests

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk

*Drawdown risk unchanged (max-DD guard still 18 %).*

------
https://chatgpt.com/codex/tasks/task_e_686c37ad5284832c95bece0aa7a5de40