### PR TITLE
[infra] add alert system

### DIFF
--- a/src/agent/convex_controller.py
+++ b/src/agent/convex_controller.py
@@ -8,6 +8,7 @@ import yaml  # type: ignore
 from ..options.deribit_router import DeribitRouter
 from ..options.position_manager import PositionManager
 from ..options.screener import find_candidates
+from src.infra import send_alert
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ def run_convex(
         premium = price * size
         if pm.open_premium() + premium > budget:
             logger.info("Budget exhausted")
+            send_alert("Convex sleeve budget exhausted")
             continue
         try:
             router.place_order(opt["symbol"], "buy", size, price)

--- a/src/agent/meta_controller.py
+++ b/src/agent/meta_controller.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 import pandas as pd
+from src.infra import send_alert
 
 logger = logging.getLogger(__name__)
 _LOG = Path("logs/meta_events.jsonl")
@@ -40,4 +41,5 @@ class MetaController:
             f.write(json.dumps(evt) + "\n")
         logger.info("Meta eval %s", evt)
         if sharpe < self.sharpe_floor or hit < self.hitrate_floor:
+            send_alert("Kill-switch triggered")
             raise RuntimeError("Kill-switch triggered")

--- a/src/data_ingest/price_loader.py
+++ b/src/data_ingest/price_loader.py
@@ -6,6 +6,7 @@ import ccxt
 import pandas as pd
 import logging
 import time
+from src.infra import send_alert
 
 
 class PriceLoader:
@@ -43,6 +44,7 @@ class PriceLoader:
                 self.logger.warning("fetch_ohlcv failed: %s", exc)
                 time.sleep(0.5)
         else:
+            send_alert(f"CCXT fetch failed for {symbol}")
             raise RuntimeError(f"failed to fetch {symbol}") from last_exc
 
         df = pd.DataFrame(ohlcv, columns=["ts", "o", "h", "l", "c", "v"])

--- a/src/infra/__init__.py
+++ b/src/infra/__init__.py
@@ -1,0 +1,3 @@
+from .alert import send_alert
+
+__all__ = ["send_alert"]

--- a/src/infra/alert.py
+++ b/src/infra/alert.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import smtplib
+from email.message import EmailMessage
+
+
+def send_alert(msg: str) -> None:
+    """Send an alert via stdout or email.
+
+    If the ``ALERT_EMAIL`` environment variable is set, an email is attempted
+    via localhost SMTP. Otherwise the message is printed to stdout.
+    """
+    email = os.getenv("ALERT_EMAIL")
+    if email:  # pragma: no cover - requires SMTP
+        message = EmailMessage()
+        message.set_content(msg)
+        message["Subject"] = "COCE alert"
+        message["From"] = email
+        message["To"] = email
+        try:
+            with smtplib.SMTP("localhost") as smtp:  # pragma: no cover - local smtp
+                smtp.send_message(message)  # pragma: no cover - local smtp
+        except Exception as exc:  # pragma: no cover - depends on local smtp
+            print(f"ALERT FAILED: {exc} | {msg}")
+    else:
+        print(f"ALERT: {msg}")

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -1,0 +1,74 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+import yaml
+
+from src.agent.meta_controller import MetaController
+from src.agent.convex_controller import run_convex
+from src.data_ingest.price_loader import PriceLoader
+
+
+class FakeRouter:
+    def __init__(self):
+        self.orders = []
+
+    def place_order(self, symbol, side, size, price=None):
+        self.orders.append({"symbol": symbol, "side": side, "size": size, "price": price})
+
+    def fetch_price(self, symbol):
+        return 0.0
+
+
+def fake_find_candidates(_cfg):
+    exp = datetime.now(timezone.utc) + timedelta(days=1)
+    return pd.DataFrame(
+        [
+            {"symbol": "BTC", "price": 30.0, "size": 1.0, "expiry": exp},
+            {"symbol": "ETH", "price": 30.0, "size": 1.0, "expiry": exp},
+        ]
+    )
+
+
+def test_kill_switch_alert(tmp_path, monkeypatch):
+    log = tmp_path / "trades.jsonl"
+    log.write_text(json.dumps({"ts": datetime.now(timezone.utc).isoformat(), "pnl": -1}) + "\n")
+    mc = MetaController(log, sharpe_floor=1.0, hitrate_floor=1.0)
+    called = []
+    monkeypatch.setattr("src.agent.meta_controller.send_alert", lambda msg: called.append(msg))
+    with pytest.raises(RuntimeError):
+        mc.evaluate()
+    assert called
+
+
+def test_ccxt_error_alert(monkeypatch):
+    pl = PriceLoader()
+    monkeypatch.setattr(pl.ex, "fetch_ohlcv", lambda *a, **k: (_ for _ in ()).throw(Exception("fail")))
+    called = []
+    monkeypatch.setattr("src.data_ingest.price_loader.send_alert", lambda msg: called.append(msg))
+    with pytest.raises(RuntimeError):
+        pl.load("BTC/USDT", datetime(1970, 1, 1, tzinfo=timezone.utc), datetime(1970, 1, 2, tzinfo=timezone.utc))
+    assert called
+
+
+def test_convex_budget_alert(tmp_path, monkeypatch):
+    cfg = {
+        "budget_pct_nav": 0.5,
+        "exchange": "deribit",
+        "moneyness": 1.0,
+        "days_to_expiry": [1],
+        "iv_percentile_max": 100,
+        "slippage_bps": 0,
+        "take_profit_pct": 100,
+        "cache_ttl_min": 1,
+    }
+    path = tmp_path / "sleeve.yaml"
+    path.write_text(yaml.safe_dump(cfg))
+
+    router = FakeRouter()
+    called = []
+    monkeypatch.setattr("src.agent.convex_controller.send_alert", lambda msg: called.append(msg))
+    monkeypatch.setattr("src.agent.convex_controller.find_candidates", fake_find_candidates)
+    run_convex(100.0, str(path), router=router)
+    assert called


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [x] Feature
- [ ] Refactor / chore

### Description
- added `src/infra/alert.py` with new `send_alert` helper
- alerts triggered on kill-switch, ccxt failures and convex sleeve budget exhaustion
- regression tests verifying alert calls

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=92
docker build .
```

### Risk

*Drawdown risk unchanged (max-DD guard still 18 %).*

------
https://chatgpt.com/codex/tasks/task_e_686c39924d90832c8b5cff42f8f00385