### PR TITLE
[feature] sentiment filter tweaks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -796,6 +796,21 @@ files = [
 ]
 
 [[package]]
+name = "langdetect"
+version = "1.0.9"
+description = "Language detection library ported from Google's language-detection."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "langdetect-1.0.9-py2-none-any.whl", hash = "sha256:7cbc0746252f19e76f77c0b1690aadf01963be835ef0cd4b56dddf2a8f1dfc2a"},
+    {file = "langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "multidict"
 version = "6.6.3"
 description = "multidict implementation"
@@ -2350,4 +2365,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "867207a3d692978109427e09fb7423e68a537abfe0c609970be3149fba4cee8b"
+content-hash = "0a97abd78e5ccbbcecf67e77a3e903f6a919f81f3e5959d65b9609bc4dff35b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python-dotenv = "^1.0"
 tqdm = "^4.66"
 joblib = "^1.4"
 requests = "^2.32"
+langdetect = "^1.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4"

--- a/src/data_ingest/social_scraper.py
+++ b/src/data_ingest/social_scraper.py
@@ -1,5 +1,9 @@
 import os
+from datetime import datetime
+from typing import Any
+
 import tweepy
+from langdetect import detect
 from textblob import TextBlob
 
 TWITTER_BEARER = os.environ.get("TWITTER_BEARER", "")
@@ -16,18 +20,31 @@ class SocialScraper:
         self.client = tweepy.Client(bearer_token=TWITTER_BEARER, wait_on_rate_limit=True)
 
     def fetch_recent(self, symbol: str, n: int = 20) -> list[str]:
-        """
-        Fetches recent tweets mentioning the base asset (BTC, ETH, etc.)
-        Returns a list of tweet texts (English, no retweets).
-        """
+        """Return recent English tweets mentioning ``symbol`` sans duplicates."""
+
         base = symbol.split("/")[0]
         try:
-            query = f'"{base}" -is:retweet lang:en'
-            tweets = (
-                self.client.search_recent_tweets(query=query, max_results=min(n, 100)).data or []
+            query = f'"{base}" -is:retweet'
+            resp: Any = self.client.search_recent_tweets(
+                query=query,
+                max_results=min(n, 100),
+                tweet_fields=["author_id", "created_at"],
             )
-            sanitized = []
+            tweets = resp.data or []
+            sanitized: list[str] = []
+            last_seen: dict[str, datetime] = {}
             for t in tweets:
+                try:
+                    if detect(t.text) != "en":
+                        continue
+                except Exception:
+                    continue
+                ts = t.created_at
+                uid = str(t.author_id)
+                prev = last_seen.get(uid)
+                if prev and (ts - prev).total_seconds() < 300:
+                    continue
+                last_seen[uid] = ts
                 text = t.text.replace("\n", " ")[:280]
                 sanitized.append(text.encode("utf-8", "ignore").decode("utf-8"))
             return sanitized
@@ -39,7 +56,7 @@ class SocialScraper:
         """
         Returns the average sentiment polarity across all posts.
         """
-        if not posts:
+        if not posts or len(posts) < 3:
             return 0.0
         try:
             clean = [p[:280] for p in posts]

--- a/tests/test_sentiment_filter.py
+++ b/tests/test_sentiment_filter.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from datetime import datetime, timedelta, timezone
+
+import sys
+
+
+class DummyTweepy:
+    class Client:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+
+sys.modules.setdefault("tweepy", DummyTweepy)
+
+from src.data_ingest import social_scraper
+from src.data_ingest.social_scraper import SocialScraper
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        ts = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        self.data = [
+            SimpleNamespace(text="hello world", author_id="u1", created_at=ts),
+            SimpleNamespace(text="bonjour le monde", author_id="u1", created_at=ts + timedelta(minutes=1)),
+            SimpleNamespace(text="spam spam", author_id="u1", created_at=ts + timedelta(minutes=2)),
+            SimpleNamespace(text="another tweet", author_id="u2", created_at=ts + timedelta(minutes=1)),
+        ]
+
+    def search_recent_tweets(self, *a, **k):
+        return SimpleNamespace(data=self.data)
+
+
+def test_filter_and_polarity(monkeypatch):
+    monkeypatch.setenv("TWITTER_BEARER", "x")
+    monkeypatch.setattr(social_scraper, "TWITTER_BEARER", "x")
+    sc = SocialScraper()
+    monkeypatch.setattr(sc, "client", DummyClient())
+    posts = sc.fetch_recent("BTC/USDT")
+    assert len(posts) == 2  # dedup + language filter
+    assert sc.polarity(posts) == 0.0  # fewer than 3 unique tweets
+


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [x] Feature
- [ ] Refactor / chore

### Description
- add language detection and per-user dedup logic in `SocialScraper`
- return zero score if <3 tweets
- add `langdetect` dependency
- test spam filtering with dummy tweets

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk

*Drawdown risk unchanged (max-DD guard still 18 %).*

------
https://chatgpt.com/codex/tasks/task_e_686c39906194832c9009e0295df91fa2