### PR TITLE
[feat] monitor tick stop loss

### DIFF
--- a/tests/test_stop_loss.py
+++ b/tests/test_stop_loss.py
@@ -28,7 +28,7 @@ def test_stop_loss(monkeypatch):
     alt = pd.DataFrame({"ALT": [0.1, 0.1, 0.1]})
     tm.execute_signal("BTC", 0.9, price1, 1_000_000, btc, alt, 1)
 
-    price2 = pd.Series([100, 90])
-    tm.execute_signal("BTC", 0.9, price2, 1_000_000, btc, alt, 0)
+    for price in [100, 90]:
+        tm.monitor_position("BTC", price)
 
     assert any(call[1] == "sell" for call in calls)


### PR DESCRIPTION
### Change type
- [x] Feature

### Description
- add `monitor_position` in `TradeManager` to check positions on each tick
- log `STOP_LOSS` trades and exit when price hits the configured threshold
- update tests to call `monitor_position` per price tick

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk
*Drawdown risk unchanged (max-DD guard still 18 %).*

Fixes #

------
https://chatgpt.com/codex/tasks/task_e_686c398d1a30832c908ce72def4f69e4