### PR TITLE
[feat] sleeve toggle via config

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -8,3 +8,6 @@
 * HRP weights integrated into TradeManager sizing
 * Persistent state added
 * Coverage 92 %, CI gate 90 %
+
+## v0.3.1 (2025-07-08)
+* Sleeve disabled by default via config flag

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -22,3 +22,6 @@ model:
 meta:
   sharpe_floor: 1.2
   hitrate_floor: 0.6
+sleeve:
+  budget_pct_nav: 0.5
+  enabled: false

--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -49,13 +49,22 @@ def main() -> None:
 
     p = argparse.ArgumentParser()
     p.add_argument("--mode", choices=["sim"], default="sim")
-    p.add_argument("--sleeve", choices=["none", "convex"], default="none")
+    p.add_argument(
+        "--sleeve",
+        choices=["none", "convex"],
+        default=None,
+        help="override sleeve setting from config",
+    )
     p.add_argument("--config", default="config/base.yaml")
     args = p.parse_args()
     cfg = load_cfg(args.config)
     validate_cfg(cfg)
 
-    if args.sleeve == "convex":
+    sleeve_choice = args.sleeve
+    if sleeve_choice is None:
+        sleeve_choice = "convex" if cfg.get("sleeve", {}).get("enabled", False) else "none"
+
+    if sleeve_choice == "convex":
         from .convex_controller import run_convex
 
         run_convex(cfg["capital_usd"], "config/sleeve.yaml")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -2,7 +2,10 @@ from src.utils.config_validation import validate_cfg
 
 
 def test_validate_cfg_ok():
-    cfg = {"risk": {"max_drawdown_pct": 18, "adv_cap_pct": 2}, "sleeve": {"budget_pct_nav": 0.5}}
+    cfg = {
+        "risk": {"max_drawdown_pct": 18, "adv_cap_pct": 2},
+        "sleeve": {"budget_pct_nav": 0.5, "enabled": False},
+    }
     validate_cfg(cfg)
 
 

--- a/tests/test_config_validation_module.py
+++ b/tests/test_config_validation_module.py
@@ -3,7 +3,7 @@ from src.utils.config_validation import validate_cfg
 
 
 def test_validate_cfg_ok():
-    validate_cfg({"risk": {"max_drawdown_pct": 10, "adv_cap_pct": 1}, "sleeve": {"budget_pct_nav": 0.4}})
+    validate_cfg({"risk": {"max_drawdown_pct": 10, "adv_cap_pct": 1}, "sleeve": {"budget_pct_nav": 0.4, "enabled": False}})
 
 
 def test_validate_cfg_fail():

--- a/tests/test_sentiment_filter.py
+++ b/tests/test_sentiment_filter.py
@@ -12,8 +12,8 @@ class DummyTweepy:
 
 sys.modules.setdefault("tweepy", DummyTweepy)
 
-from src.data_ingest import social_scraper
-from src.data_ingest.social_scraper import SocialScraper
+from src.data_ingest import social_scraper  # noqa: E402
+from src.data_ingest.social_scraper import SocialScraper  # noqa: E402
 
 
 class DummyClient:


### PR DESCRIPTION
### Change type
- [ ] Bug-fix
- [x] Feature
- [ ] Refactor / chore

### Description
- Added `enabled` flag under `sleeve` in `config/base.yaml` to disable convex sleeve by default.
- `run_agent.py` now checks the config flag unless CLI overrides it.
- Documented rationale in `AUDIT.md`.
- Updated config validation tests and fixed lint issue in sentiment test.

### Validation
```bash
poetry run ruff check .
poetry run mypy src
poetry run pytest --cov=src --cov-fail-under=90
docker build .
```

### Risk
*Drawdown risk unchanged (max-DD guard still 18 %).*

Fixes #

------
https://chatgpt.com/codex/tasks/task_e_686c3c6004f4832c87e55e3488b04126